### PR TITLE
Add dependabot.yml, targeting develop for PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    target-branch: "develop"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Configures Dependabot version-update PRs (uv ecosystem, weekly) to open against develop instead of main.